### PR TITLE
fix: update raven server configuration and paths in docker-compose

### DIFF
--- a/mail-infra/services/config-scripts/gen-postfix-conf.sh
+++ b/mail-infra/services/config-scripts/gen-postfix-conf.sh
@@ -103,7 +103,7 @@ maillog_file = /var/log/mail.log
 
 # SASL authentication provided by Raven server via Unix socket
 smtpd_sasl_type = dovecot
-smtpd_sasl_path = inet:raven:12345
+smtpd_sasl_path = inet:raven-sasl:12345
 smtpd_sasl_auth_enable = yes
 smtpd_sasl_security_options = noanonymous
 broken_sasl_auth_clients = yes

--- a/mail-infra/services/docker-compose.yaml
+++ b/mail-infra/services/docker-compose.yaml
@@ -11,7 +11,6 @@ services:
       - ./silver-config/postfix/recipient_access:/etc/postfix/recipient_access:ro
       - ../conf/silver.yaml:/etc/postfix/silver.yaml
       - ./silver-config/certbot/keys/etc:/etc/letsencrypt:ro
-      - ./silver-config/raven/data:/app/data:rw
       - postfix-spool:/var/spool/postfix
       - postfix-logs:/var/log
     networks:
@@ -19,20 +18,17 @@ services:
     depends_on:
       - opendkim-server
       - certbot-server
-      - raven-server
+      - raven-sasl-server
 
-  raven-server:
-    image: ghcr.io/lsflk/raven:latest
-    container_name: raven
+  raven-sasl-server:
+    image: ghcr.io/lsflk/raven-sasl:latest
+    container_name: raven-sasl
     ports:
-      - "143:143"
-      - "993:993"
-      - "24:24"
       - "12345:12345"
     volumes:
       - ./silver-config/raven/conf:/etc/raven:rw
-      - ./silver-config/raven/data:/app/data:rw
       - ./silver-config/raven/certs:/certs:ro
+      - postfix-spool:/var/spool/postfix
     environment:
       - DB_FILE=/app/data/databases/shared.db
     networks:


### PR DESCRIPTION
This PR is to remove imap and lmtp servers from the Raven and only use SASL authentication for this.