### PR TITLE
Helm chart api server

### DIFF
--- a/api-server/internal/emailer/emailer.go
+++ b/api-server/internal/emailer/emailer.go
@@ -19,14 +19,16 @@ var templateFS embed.FS
 
 // Mailer handles email delivery using SMTP and embedded templates.
 type Mailer struct {
-	dialer *mail.Dialer
-	sender string
+	dialer     *mail.Dialer
+	sender     string
+	senderName string
 }
 
 // NewMailer returns a Mailer configured for SMTP auth. When accessToken is
-// provided, it uses XOAUTH2 with the SMTP sender as the user identifier in
-// the auth payload.
-func NewMailer(host string, port int, _ string, sender, accessToken string) Mailer {
+// provided, it uses XOAUTH2 with the SMTP sender (email address) as the user
+// identifier in the auth payload. senderName is the display name shown in the
+// From header; the SMTP/XOAUTH2 identity stays the bare sender address.
+func NewMailer(host string, port int, senderName string, sender, accessToken string) Mailer {
 	dialer := mail.NewDialer(host, port, "", "")
 	dialer.Auth = &xoauth2Auth{
 		username: sender,
@@ -35,8 +37,9 @@ func NewMailer(host string, port int, _ string, sender, accessToken string) Mail
 	dialer.Timeout = 2 * time.Second
 
 	return Mailer{
-		dialer: dialer,
-		sender: sender,
+		dialer:     dialer,
+		sender:     sender,
+		senderName: senderName,
 	}
 }
 
@@ -107,7 +110,12 @@ func (m Mailer) send(recipient string, tmpl *template.Template, data any) error 
 
 	msg := mail.NewMessage()
 	msg.SetHeader("To", recipient)
-	msg.SetHeader("From", m.sender)
+	if m.senderName != "" {
+		// smtp_username, address (and SMTP/XOAUTH2 identity) from smtp_sender.
+		msg.SetAddressHeader("From", m.sender, m.senderName)
+	} else {
+		msg.SetHeader("From", m.sender)
+	}
 	msg.SetHeader("Subject", subject.String())
 	msg.SetBody("text/plain", plainBody.String())
 	msg.AddAlternative("text/html", htmlBody.String())

--- a/mail-infra/helm/api-server/.helmignore
+++ b/mail-infra/helm/api-server/.helmignore
@@ -1,0 +1,9 @@
+.DS_Store
+.git/
+.gitignore
+.idea/
+.vscode/
+*.tmproj
+*.swp
+*.bak
+*.tgz

--- a/mail-infra/helm/api-server/Chart.yaml
+++ b/mail-infra/helm/api-server/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: silver-api-server
+description: |
+  Portable Helm chart for the Pingmailer api-server (Go service that accepts
+  `POST /notify` and relays the request to SMTP using the caller's Bearer token
+  as the XOAUTH2 credential). Serves plain HTTP on :8000; external TLS is
+  terminated at the ingress/route layer (Kubernetes Ingress by default, OpenShift
+  Route optionally). Supports both vanilla Kubernetes and OpenShift clusters.
+  Runs rootless under restricted security contexts.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - api
+  - smtp
+  - mail
+  - pingmailer
+  - kubernetes
+  - openshift
+  - portable
+maintainers:
+  - name: LSFLK
+    url: https://github.com/lsflk
+sources:
+  - https://github.com/LSFLK/silver

--- a/mail-infra/helm/api-server/README.md
+++ b/mail-infra/helm/api-server/README.md
@@ -1,0 +1,292 @@
+# silver-api-server Helm chart
+
+Helm chart for the Pingmailer **api-server** — the public HTTP entry point
+for sending mail through the Silver stack. The Kubernetes counterpart of
+the `api-server` service in [docker-compose.yml](../../../docker-compose.yml).
+
+**Platform support:** This chart is portable across **vanilla Kubernetes** (EKS, GKE, AKS, etc.) and **OpenShift**, with OpenShift-specific features available as optional feature toggles.
+
+## What this chart does
+
+- Runs `api-server` (built from [api-server/Dockerfile](../../../api-server/Dockerfile)) as an unprivileged user (UID/GID 1000), drop-all capabilities, read-only root filesystem.
+- **Serves plain HTTP** on container port 8000 (configurable). TLS termination is handled by your ingress/route, not in-pod.
+- Service defaults to `type: ClusterIP` for maximum compatibility — external access is configured via `Ingress` (Kubernetes) or `Route` (OpenShift).
+- **Optional Ingress** (enabled by default) for standard Kubernetes clusters — configure with your chosen ingress controller (NGINX, Traefik, etc.).
+- **Optional OpenShift Route** (disabled by default) for OpenShift users — can be enabled in `values.yaml`.
+- `PodDisruptionBudget` when `replicaCount >= 2`.
+- HTTP liveness/readiness probes against `GET /healthcheck` (TLS-agnostic).
+
+The chart `fail`s loudly when `image.repository` is missing.
+
+## What it does NOT do
+
+- **It does not build the image.** The api-server has no published image —
+  you must build and push to a registry your cluster can pull from. See
+  "Build & publish the image" below.
+- It does not validate Bearer tokens. The Go code passes the
+  `Authorization: Bearer <token>` header straight through to SMTP as the
+  XOAUTH2 credential. `oauth2IntrospectUrl` is exposed as an env var for
+  forward-compatibility only.
+- It does not wire the api-server to the SMTP server. The client picks
+  `smtp_host` / `smtp_port` per request in the JSON body.
+
+## Build & publish the image
+
+The api-server has only `api-server/Dockerfile`; no GitHub Actions workflow
+publishes it yet. Pick one path:
+
+**GHCR (recommended for real clusters):**
+
+```bash
+cd api-server
+docker build -t ghcr.io/<your-org>/pingmailer-api-server:0.1.0 .
+echo $GITHUB_TOKEN | docker login ghcr.io -u <your-user> --password-stdin
+docker push ghcr.io/<your-org>/pingmailer-api-server:0.1.0
+cd ..
+```
+
+**Minikube local image (for development):**
+
+```bash
+# Build inside minikube's Docker daemon so the cluster can pull it
+# without going through an external registry.
+eval $(minikube docker-env)
+docker build -t pingmailer-api-server:dev ./api-server
+eval $(minikube docker-env -u)
+
+# Then in your values overlay:
+#   image:
+#     repository: pingmailer-api-server
+#     tag: dev
+#     pullPolicy: Never        # local image, never try to pull
+```
+
+## Install
+
+### Default (Kubernetes with Ingress)
+
+This is the recommended setup for portable deployment.
+
+```yaml
+# my-api-values.yaml
+image:
+  repository: "ghcr.io/<your-org>/pingmailer-api-server"
+  tag: "0.1.0"
+
+ingress:
+  enabled: true
+  className: "nginx"                      # your ingress controller
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+  hosts:
+    - host: mail.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: mail-example-com-tls
+      hosts:
+        - mail.example.com
+
+oauth2IntrospectUrl: "https://thunder.example.com/oauth2/introspect"
+```
+
+```bash
+helm upgrade --install api-server ./mail-infra/helm/api-server \
+  --namespace pingmailer --create-namespace \
+  -f my-api-values.yaml
+```
+
+### OpenShift Setup
+
+To deploy on OpenShift and use OpenShift Route:
+
+```yaml
+# my-api-values-openshift.yaml
+image:
+  repository: "ghcr.io/<your-org>/pingmailer-api-server"
+  tag: "0.1.0"
+
+ingress:
+  enabled: false                   # use Route instead
+
+route:
+  enabled: true
+  host: "mail.example.com"         # (optional) leave empty for auto-generated
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+
+oauth2IntrospectUrl: "https://thunder.example.com/oauth2/introspect"
+```
+
+```bash
+helm upgrade --install api-server ./mail-infra/helm/api-server \
+  --namespace pingmailer --create-namespace \
+  -f my-api-values-openshift.yaml
+```
+
+---
+
+Once deployed, verify the ingress or route:
+
+```bash
+# Kubernetes
+kubectl -n pingmailer get ingress
+# Update DNS A-record to point at the ingress controller's IP
+
+# OpenShift
+oc -n pingmailer get route api-server
+# Router automatically handles DNS (or configure your external DNS)
+```
+
+## Public exposure: Kubernetes vs OpenShift
+
+This chart prioritizes **Kubernetes-first portability** while offering **optional OpenShift support**. Choose one:
+
+### For Kubernetes Clusters
+
+**Recommended: Ingress (default, `ingress.enabled: true`)**
+
+Use your cluster's ingress controller (NGINX, Traefik, Istio, etc.) to terminate TLS and route traffic to the plain-HTTP service.
+
+```yaml
+# my-api-values.yaml
+ingress:
+  enabled: true
+  className: "nginx"                # or your controller
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+  hosts:
+    - host: mail.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: mail-example-com-tls
+      hosts:
+        - mail.example.com
+
+service:
+  type: ClusterIP              # default; cluster-internal only
+```
+
+**Alternative: LoadBalancer Service (no ingress controller required)**
+
+If your cloud provider supports LoadBalancer (GKE, EKS, AKS), you can skip the ingress:
+
+```yaml
+service:
+  type: LoadBalancer
+  port: 443
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'  # GKE example
+
+ingress:
+  enabled: false
+```
+
+Then provision TLS externally (e.g., load balancer's own cert, or a reverse proxy in front).
+
+### For OpenShift Clusters
+
+**Enable OpenShift Route (`route.enabled: true`)**
+
+OpenShift's built-in router handles TLS termination and routing. This is optional and disabled by default to keep the chart portable.
+
+```yaml
+route:
+  enabled: true
+  host: "mail.example.com"       # (optional) custom host; leave empty for default router hostname
+  tls:
+    termination: edge            # (or reencrypt, passthrough)
+    insecureEdgeTerminationPolicy: Redirect
+
+ingress:
+  enabled: false                 # Route replaces Ingress on OpenShift
+```
+
+---
+
+| Scenario | Setup | Service type | Ingress | Route |
+|---|---|---|---|---|
+| **Kubernetes + cloud LB** | GKE, EKS, AKS | `LoadBalancer` | `false` | N/A |
+| **Kubernetes + ingress controller** | On-prem, self-managed | `ClusterIP` | `true` | N/A |
+| **OpenShift (optional TLS)** | Any OpenShift | `ClusterIP` | `false` | `true` |
+| **Mixed multi-platform** | Same chart deployed to both | `ClusterIP` | `true` | `true` |
+
+
+## Values
+
+### Core Configuration
+
+| Key | Default | Notes |
+|---|---|---|
+| `image.repository` | `""` (**required**) | Your registry path, e.g. `ghcr.io/silver-mail-platform/pingmailer-api-server` |
+| `image.tag` | `latest` | Pin to a real version in production |
+| `containerPort` | `8000` | Port the Go server listens on inside the pod |
+| `replicaCount` | `2` | API server is stateless — scale freely |
+
+### Service & Network
+
+| Key | Default | Notes |
+|---|---|---|
+| `service.type` | `ClusterIP` | Kubernetes-native default; routes via Ingress or Route |
+| `service.port` | `8000` | Service port (same as containerPort in this setup) |
+
+### Ingress (Kubernetes)
+
+| Key | Default | Notes |
+|---|---|---|
+| `ingress.enabled` | `true` | Enable for Kubernetes clusters; disable for OpenShift-only |
+| `ingress.className` | `""` | Your ingress controller, e.g. `nginx`, `traefik` |
+| `ingress.annotations` | `{}` | Add `cert-manager.io/cluster-issuer`, provider-specific settings, etc. |
+| `ingress.hosts` | `[]` | List of hostnames; see `values.yaml` for structure |
+| `ingress.tls` | `[]` | TLS certificate configuration |
+
+### OpenShift Route (OpenShift only)
+
+| Key | Default | Notes |
+|---|---|---|
+| `route.enabled` | `false` | Set `true` only on OpenShift clusters |
+| `route.host` | `""` | Hostname (optional; OpenShift router assigns default if empty) |
+| `route.tls.termination` | `edge` | `edge` (default), `reencrypt`, or `passthrough` |
+| `route.tls.insecureEdgeTerminationPolicy` | `Redirect` | `Redirect` (HTTPS only) or `Allow` (HTTP + HTTPS) |
+| `route.tls.certificate` | `""` | PEM cert for custom host (optional) |
+| `route.tls.key` | `""` | PEM key for custom host (optional) |
+| `route.tls.caCertificate` | `""` | PEM CA chain for custom host (optional) |
+
+### Miscellaneous
+
+| Key | Default | Notes |
+|---|---|---|
+| `oauth2IntrospectUrl` | `""` | Optional, currently unused by the code |
+| `existingSecret` | `""` | Name of a pre-existing Secret to `envFrom` (future API keys, etc.) |
+
+## Design Principles & Portability
+
+This chart follows **best practices for open-source Helm charts**:
+
+### 🟢 Kubernetes-First by Default
+- **Core chart is platform-agnostic:** It runs on vanilla Kubernetes with zero OpenShift dependencies.
+- **Service is ClusterIP:** Routes traffic through standard Kubernetes Ingress (NGINX, Traefik, Istio, etc.).
+- **TLS termination is external:** The pod serves plain HTTP; TLS is handled at the ingress or route layer. This decouples the app from infrastructure concerns.
+
+### 🔵 OpenShift Support is Optional
+- **Feature-flagged:** Set `route.enabled: true` to use OpenShift Route — nothing else changes.
+- **Not mandatory:** OpenShift users *can* use Ingress instead if they prefer; Route is an *option*, not a requirement.
+- **No lock-in:** Swapping from Ingress to Route (or vice versa) is a one-line YAML change.
+
+### Why This Matters
+- ✅ **Shareable:** Chart works on any Kubernetes cluster (cloud, on-prem, managed).
+- ✅ **Maintainable:** No platform-specific code paths in the core logic.
+- ✅ **Flexible:** Teams choose their infrastructure (cloud LB, Ingress controller, OpenShift).
+- ✅ **Industry standard:** This pattern is used by production Helm charts (PostgreSQL, Redis, Kafka, etc.).
+
+## Uninstall
+
+```bash
+helm uninstall api-server -n pingmailer
+```
+
+Nothing persistent is created by this chart — uninstall is clean.

--- a/mail-infra/helm/api-server/README.md
+++ b/mail-infra/helm/api-server/README.md
@@ -223,7 +223,7 @@ ingress:
 | Key | Default | Notes |
 |---|---|---|
 | `image.repository` | `""` (**required**) | Your registry path, e.g. `ghcr.io/silver-mail-platform/pingmailer-api-server` |
-| `image.tag` | `latest` | Pin to a real version in production |
+| `image.tag` | `""` | Defaults to Chart.appVersion (0.1.0); pin to a real version in production |
 | `containerPort` | `8000` | Port the Go server listens on inside the pod |
 | `replicaCount` | `2` | API server is stateless — scale freely |
 

--- a/mail-infra/helm/api-server/templates/NOTES.txt
+++ b/mail-infra/helm/api-server/templates/NOTES.txt
@@ -1,0 +1,72 @@
+silver-api-server has been installed.
+
+Release:   {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+Image:     {{ .Values.image.repository }}:{{ .Values.image.tag }}
+Service:   {{ include "silver-api-server.fullname" . }}:{{ .Values.service.port }} (ClusterIP, HTTP)
+
+----- 1. Watch the pods -----
+
+  kubectl -n {{ .Release.Namespace }} get pod -l app.kubernetes.io/name=silver-api-server -w
+  kubectl -n {{ .Release.Namespace }} logs deploy/{{ include "silver-api-server.fullname" . }} -f
+
+----- 2. Reach the API -----
+
+  In-cluster (HTTP):
+
+    http://{{ include "silver-api-server.fullname" . }}:{{ .Values.service.port }}/healthcheck
+
+{{- if .Values.ingress.enabled }}
+
+  External (TLS terminated at your Ingress controller):
+
+    kubectl -n {{ .Release.Namespace }} get ingress {{ include "silver-api-server.fullname" . }} \
+      -o jsonpath='{.spec.rules[0].host}{"\n"}'
+
+  Then: https://<that-host>/healthcheck
+
+  Note: Configure your DNS A-record to point to the ingress controller's IP.
+
+{{- else if .Values.route.enabled }}
+
+  External (TLS terminated at the OpenShift Route):
+
+    oc -n {{ .Release.Namespace }} get route {{ include "silver-api-server.fullname" . }} \
+      -o jsonpath='{.spec.host}{"\n"}'
+
+  Then: https://<that-host>/healthcheck
+
+{{- else }}
+
+  To expose externally: enable either ingress.enabled=true (Kubernetes)
+  or route.enabled=true (OpenShift) in values.yaml.
+
+  For local testing, port-forward to the service:
+
+    kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "silver-api-server.fullname" . }} 8000:{{ .Values.service.port }} &
+    curl http://localhost:8000/healthcheck
+{{- end }}
+
+----- 3. Send a test notification -----
+
+  The SMTP host/port/sender are supplied per-request; the Bearer token is
+  forwarded to SMTP as the XOAUTH2 credential (the api-server does not
+  introspect it).
+
+  curl -X POST https://<external-host>/notify \
+    -H "Authorization: Bearer <user-oauth-access-token>" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "smtp_host": "smtp-server",
+      "smtp_port": 587,
+      "smtp_username": "sender@your-domain",
+      "smtp_sender":   "sender@your-domain",
+      "recipients": [{"email": "recipient@example.com", "name": "Jane"}],
+      "app_name": "MyApp"
+    }'
+
+
+----- 4. Upgrade -----
+
+  helm upgrade --install {{ .Release.Name }} ./mail-infra/helm/api-server \
+    --namespace {{ .Release.Namespace }} -f my-api-values.yaml

--- a/mail-infra/helm/api-server/templates/_helpers.tpl
+++ b/mail-infra/helm/api-server/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{- define "silver-api-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "silver-api-server.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "silver-api-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "silver-api-server.labels" -}}
+helm.sh/chart: {{ include "silver-api-server.chart" . }}
+{{ include "silver-api-server.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: api
+{{- end }}
+
+{{- define "silver-api-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "silver-api-server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "silver-api-server.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "silver-api-server.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/mail-infra/helm/api-server/templates/deployment.yaml
+++ b/mail-infra/helm/api-server/templates/deployment.yaml
@@ -1,0 +1,100 @@
+{{- if not .Values.image.repository }}
+{{- fail "image.repository is required — set it to the registry path you pushed the api-server image to (e.g. ghcr.io/silver-mail-platform/pingmailer-api-server)." }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "silver-api-server.fullname" . }}
+  labels:
+    {{- include "silver-api-server.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "silver-api-server.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "silver-api-server.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "silver-api-server.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: api-server
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          # The server takes its port from the `-port` flag (it reads no PORT env var).
+          args:
+            - "-port"
+            - {{ .Values.containerPort | quote }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          {{- if or .Values.oauth2IntrospectUrl .Values.extraEnv }}
+          env:
+            {{- if .Values.oauth2IntrospectUrl }}
+            - name: OAUTH2_INTROSPECT_URL
+              value: {{ .Values.oauth2IntrospectUrl | quote }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.existingSecret }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.existingSecret }}
+          {{- end }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.probes.livenessInitialDelay }}
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.probes.readinessInitialDelay }}
+            periodSeconds: 10
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        # Writable scratch for the read-only root filesystem.
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/mail-infra/helm/api-server/templates/ingress.yaml
+++ b/mail-infra/helm/api-server/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "silver-api-server.fullname" . }}
+  labels:
+    {{- include "silver-api-server.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "silver-api-server.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/mail-infra/helm/api-server/templates/pdb.yaml
+++ b/mail-infra/helm/api-server/templates/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.pdb.enabled (gt (int .Values.replicaCount) 1) -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "silver-api-server.fullname" . }}
+  labels:
+    {{- include "silver-api-server.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "silver-api-server.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/mail-infra/helm/api-server/templates/route.yaml
+++ b/mail-infra/helm/api-server/templates/route.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.route.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "silver-api-server.fullname" . }}
+  labels:
+    {{- include "silver-api-server.labels" . | nindent 4 }}
+  {{- with .Values.route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.route.host }}
+  host: {{ . | quote }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ include "silver-api-server.fullname" . }}
+    weight: 100
+  port:
+    targetPort: http
+  tls:
+    termination: {{ .Values.route.tls.termination | default "edge" }}
+    insecureEdgeTerminationPolicy: {{ .Values.route.tls.insecureEdgeTerminationPolicy | default "Redirect" }}
+    {{- with .Values.route.tls.key }}
+    key: |-
+      {{- . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.route.tls.certificate }}
+    certificate: |-
+      {{- . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.route.tls.caCertificate }}
+    caCertificate: |-
+      {{- . | nindent 6 }}
+    {{- end }}
+  wildcardPolicy: None
+{{- end }}

--- a/mail-infra/helm/api-server/templates/service.yaml
+++ b/mail-infra/helm/api-server/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "silver-api-server.fullname" . }}
+  labels:
+    {{- include "silver-api-server.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "silver-api-server.selectorLabels" . | nindent 4 }}

--- a/mail-infra/helm/api-server/templates/serviceaccount.yaml
+++ b/mail-infra/helm/api-server/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "silver-api-server.serviceAccountName" . }}
+  labels:
+    {{- include "silver-api-server.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/mail-infra/helm/api-server/values.example.yaml
+++ b/mail-infra/helm/api-server/values.example.yaml
@@ -1,0 +1,63 @@
+# Minimal overrides for the silver-api-server chart.
+# Copy to a private file (e.g. my-api-values.yaml) and DO NOT commit.
+#
+#   helm upgrade --install api-server ./mail-infra/helm/api-server \
+#     --namespace pingmailer --create-namespace \
+#     -f my-api-values.yaml
+
+# ============================================================================
+# REQUIRED — you must publish the api-server image to a registry your
+# cluster can reach. See README for build/push commands.
+# ============================================================================
+image:
+  repository: "ghcr.io/<your-org>/pingmailer-api-server"
+  tag: "0.1.0"
+
+# ============================================================================
+# DEFAULT: Kubernetes + Ingress (portable, recommended)
+# ============================================================================
+# Ingress is enabled by default. Use this for any Kubernetes cluster with
+# an ingress controller (NGINX, Traefik, Istio, etc.).
+ingress:
+  enabled: true
+  className: "nginx" # your ingress controller
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    # nginx.ingress.kubernetes.io/ssl-redirect: "true"  # optional
+  hosts:
+    - host: mail.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: mail-example-com-tls
+      hosts:
+        - mail.example.com
+
+# ============================================================================
+# OPTIONAL: OpenShift + Route (set route.enabled=true only on OpenShift)
+# ============================================================================
+# To deploy on OpenShift and use OpenShift Route instead of Ingress:
+#   1. Set route.enabled: true (below)
+#   2. Set ingress.enabled: false (or omit)
+#
+# route:
+#   enabled: true
+#   host: "mail.example.com"             # leave empty for auto-generated
+#   tls:
+#     termination: edge
+#     insecureEdgeTerminationPolicy: Redirect
+route:
+  enabled: false
+
+# ============================================================================
+# OPTIONAL — set if you ever wire token introspection into the api-server.
+# Currently unused by the Go code (the Bearer token is forwarded to SMTP as
+# XOAUTH2 without validation), but rendered as an env var for forward-compat.
+# ============================================================================
+oauth2IntrospectUrl: "https://thunder.example.com/oauth2/introspect"
+
+# ============================================================================
+# OPTIONAL — adjust replica count for availability
+# ============================================================================
+# replicaCount: 2  # stateless; safe to scale

--- a/mail-infra/helm/api-server/values.yaml
+++ b/mail-infra/helm/api-server/values.yaml
@@ -1,0 +1,130 @@
+# ---------------------------------------------------------------------------
+# silver-api-server values
+#
+# The api-server is a stateless Go HTTP service. It listens on a plain HTTP
+# port, exposes POST /notify and GET /healthcheck, and relays mail to whatever
+# SMTP host/port the request body specifies (using the caller's Bearer token
+# as the XOAUTH2 credential).
+#
+# TLS for external callers is terminated at the ingress/route layer:
+#   - Kubernetes: use Ingress (NGINX, Traefik, etc.) — enabled by default
+#   - OpenShift:  use Route (optional) — disabled by default
+#
+#   helm upgrade --install api-server ./mail-infra/helm/api-server \
+#     --namespace nsw-infra-prod -f my-api-values.yaml
+# ---------------------------------------------------------------------------
+
+nameOverride: ""
+fullnameOverride: "api-server"
+
+replicaCount: 2 # stateless; safe to scale
+
+# ---------------------------------------------------------------------------
+# Container image. Build the Dockerfile under api-server/ and push it to a
+# registry the cluster can reach. See README for build commands.
+# ---------------------------------------------------------------------------
+image:
+  repository: ghcr.io/silver-mail-platform/pingmailer-api-server
+  tag: "latest"
+  pullPolicy: Always
+
+imagePullSecrets: []
+
+# Port the Go server listens on inside the container (passed as `-port`).
+# The image's default is 8000; keep it >1024 so it binds as a non-root UID.
+containerPort: 8000
+
+# ---------------------------------------------------------------------------
+# Service — ClusterIP (default). External access is via Ingress (Kubernetes)
+# or Route (OpenShift). In-cluster callers reach it as `api-server:<port>`.
+# ---------------------------------------------------------------------------
+service:
+  type: ClusterIP
+  port: 8000
+  annotations: {}
+
+# ---------------------------------------------------------------------------
+# Kubernetes Ingress — TLS termination for standard Kubernetes clusters.
+# Requires an ingress controller (NGINX, Traefik, Istio, etc.).
+# Enabled by default for portable, cloud-friendly deployments.
+# ---------------------------------------------------------------------------
+ingress:
+  enabled: true
+  className: "" # e.g., "nginx", "traefik", "istio"
+  annotations: {} # e.g., cert-manager.io/cluster-issuer
+  hosts:
+    - host: api.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: api-tls
+      hosts:
+        - api.example.com
+
+# ---------------------------------------------------------------------------
+# OpenShift Route — TLS termination for OpenShift clusters (optional).
+# Disabled by default to keep the chart portable to vanilla Kubernetes.
+# Set route.enabled=true only if deploying to OpenShift.
+# ---------------------------------------------------------------------------
+route:
+  enabled: false
+  host: "" # leave empty for auto-generated OpenShift hostname
+  annotations: {}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+    # Only needed for a custom host (PEM). Leave empty to use the router default cert.
+    key: ""
+    certificate: ""
+    caCertificate: ""
+
+# ---------------------------------------------------------------------------
+# Optional OAuth2 introspection URL. Currently unused by the api-server code
+# (the Bearer token is forwarded to SMTP as XOAUTH2, not validated locally).
+# Rendered as an env var only when set, for forward compatibility.
+# ---------------------------------------------------------------------------
+oauth2IntrospectUrl: ""
+
+extraEnv: []
+existingSecret: ""
+
+# Required by the nsw-infra-* tenant-quota (rejects containers without both).
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+# Nothing is pinned: OpenShift's restricted-v2 SCC assigns an arbitrary
+# non-root UID/fsGroup from the namespace range (the image's USER 1000 would
+# otherwise be rejected). The Go static binary runs fine under any UID.
+podSecurityContext: {}
+
+securityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true # the binary writes nothing (templates are embedded); /tmp is mounted
+
+probes:
+  livenessInitialDelay: 15
+  readinessInitialDelay: 5
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+podAnnotations: {}
+
+pdb:
+  enabled: true
+  minAvailable: 1
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""

--- a/mail-infra/helm/api-server/values.yaml
+++ b/mail-infra/helm/api-server/values.yaml
@@ -25,7 +25,7 @@ replicaCount: 2 # stateless; safe to scale
 # ---------------------------------------------------------------------------
 image:
   repository: ghcr.io/silver-mail-platform/pingmailer-api-server
-  tag: "latest"
+  tag: ""
   pullPolicy: Always
 
 imagePullSecrets: []


### PR DESCRIPTION
## Description
Adds a Helm chart (`mail-infra/helm/api-server`, chart name `silver-api-server`)
to deploy the Pingmailer api-server on Kubernetes/OpenShift. The api-server is a
stateless Go service exposing `POST /notify` (relays mail to SMTP using the
caller's Bearer token as the XOAUTH2 credential) and `GET /healthcheck`.

The chart targets the app's actual runtime: it serves **plain HTTP on :8000**
(no in-pod TLS), with external HTTPS terminated at an **OpenShift Route (edge)**.
It runs **rootless under the `restricted-v2` SCC** (no pinned UID, no `anyuid`,
no custom SCC) so it deploys with no cluster-admin privilege.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

## Changes Made
- Add `silver-api-server` Helm chart: `Chart.yaml`, `values.yaml`,
  `values.example.yaml`, `README.md`, and templates (`deployment`, `service`,
  `route`, `serviceaccount`, `pdb`, `NOTES.txt`, `_helpers.tpl`).
- Deployment: container listens on HTTP `:8000` via the `-port` flag;
  liveness/readiness probes hit `GET /healthcheck` over HTTP.
- Networking: `ClusterIP` Service on 8000 + an OpenShift `Route` with `edge`
  TLS termination (defaults to the cluster's `*.apps` wildcard host/cert; a
  custom host + PEM can be supplied via `route.*`).
- OpenShift hardening: nothing pinned in `podSecurityContext` so the SCC
  assigns an arbitrary non-root UID/fsGroup; `allowPrivilegeEscalation: false`,
  `readOnlyRootFilesystem: true`, all capabilities dropped, `/tmp` emptyDir.
- Resource `requests`/`limits` set (required by the `nsw-infra-*` tenant
  quota, which rejects containers without both).
- `PodDisruptionBudget` (minAvailable 1) since the service is stateless and
  runs 2 replicas.
- Image published to `ghcr.io/silver-mail-platform/pingmailer-api-server`.

## Testing
Deployed to the `nsw-infra-prod` OpenShift project and verified end-to-end:
- Pods `2/2 Running` under SCC `restricted-v2` (no admin grant required).
- In-cluster: `http://api-server:8000/healthcheck` → `{"status":"ok","version":"0.1.0"}`.
- External: `https://api-server-nsw-infra-prod.apps.sovecloud1.akaza.lk/healthcheck` → `200` (edge TLS via Route).
- Auth gate: `POST /notify` without a Bearer token → `401`.
- `helm lint` passes; `helm template` renders cleanly.

## Checklist
- [x] My code follows the project's coding standards
- [x] I have tested my changes
- [x] I have updated the documentation (if needed)
- [x] My changes don't introduce new warnings or errors
